### PR TITLE
Add Bitso Api provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Displays Bitcoin market information in the gnome shell. Available APIs:
 * BX.in.th
 * Paymium
 * BTCChina
+* Bitso
 
 
 ## Installation

--- a/src/ApiProvider.js
+++ b/src/ApiProvider.js
@@ -692,6 +692,44 @@ const BtcChinaApi = new Lang.Class({
   }
 });
 
+const BitsoApi = new Lang.Class({
+  Name: 'BitsoApi',
+  Extends: BaseApi,
+
+  apiName: "Bitso",
+
+  currencies: ['MXN'],
+
+  /* quote https://bitso.com/api_info#rate-limits
+   *
+   * > Rate limits are are based on one minute windows. If you do more than 30
+   * > requests in a minute, you get locked out for one minute.
+   */
+  interval: 30,
+
+  attributes: {
+    last: function (options) {
+      let renderCurrency = new CurrencyRenderer(options);
+      let renderChange = new ChangeRenderer();
+
+      return {
+        text: function (data)
+          renderCurrency(data.last),
+        change: function (data)
+          renderChange(data.last)
+      };
+    }
+  },
+
+  getLabel: function(options) {
+    return "Bitso " + options.currency;
+  },
+
+  getUrl: function(options) {
+    return "https://api.bitso.com/v2/ticker";
+  }
+});
+
 
 const ApiProvider = new Lang.Class({
   Name: "ApiProvider",
@@ -704,7 +742,8 @@ const ApiProvider = new Lang.Class({
       coinbase: new CoinbaseApi(),
       bxinth: new BXinTHApi(),
       paymium: new PaymiumApi(),
-      btcchina: new BtcChinaApi()
+      btcchina: new BtcChinaApi(),
+      bitso: new BitsoApi()
     };
   },
 

--- a/src/ApiProvider.js
+++ b/src/ApiProvider.js
@@ -67,7 +67,8 @@ Soup.Session.prototype.add_feature.call(
 
 const DefaultCurrencies = [
       'USD', 'EUR', 'CNY', 'GBP', 'CAD', 'RUB', 'AUD',
-      'BRL', 'CZK', 'JPY', 'NZD', 'SEK', 'SGD', 'PLN'
+      'BRL', 'CZK', 'JPY', 'NZD', 'SEK', 'SGD', 'PLN',
+      'MXN'
 ];
 
 
@@ -163,7 +164,8 @@ const CurrencyRenderer = function ({unit, currency, decimals}) {
     const back = "%v %s";
     const frontFormats = {
       USD: front, CAD: front, AUD: front, GBP: front,
-      HKD: front, NZD: front, SGD: front, THB: front
+      HKD: front, NZD: front, SGD: front, THB: front,
+      MXN: front
     };
 
     return frontFormats[currency] || back;

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -404,6 +404,30 @@ const BtcChinaConfigView = new Lang.Class({
 
 Signals.addSignalMethods(BtcChinaConfigView.prototype);
 
+const BitsoConfigView = new Lang.Class({
+  Name: "BitsoConfigView",
+  Extends: ProviderConfigView,
+
+  _init: function (configWidget, indicatorConfig) {
+    this.parent(configWidget, indicatorConfig);
+    this._addSelectCurrency((new ApiProvider.BitsoApi()).currencies);
+  },
+
+  _setApiDefaults: function (config) {
+    if (config.get('api') !== 'bitso') {
+      config.attributes = {
+        api: 'bitso',
+        currency: 'MXN',
+        attribute: 'last'
+      };
+
+      config.emit('update');
+    }
+  },
+});
+
+Signals.addSignalMethods(BitsoConfigView.prototype);
+
 
 
 const IndicatorConfigView = new Lang.Class({
@@ -466,7 +490,8 @@ const IndicatorConfigView = new Lang.Class({
       coinbase:       function () new CoinbaseConfigView(widget, config),
       bxinth:         function () new BXinTHConfigView(widget, config),
       paymium:        function () new PaymiumConfigView(widget, config),
-      btcchina:       function () new BtcChinaConfigView(widget, config)
+      btcchina:       function () new BtcChinaConfigView(widget, config),
+      bitso:          function () new BitsoConfigView(widget, config)
     };
 
     if (this._apiConfigView) {
@@ -493,7 +518,8 @@ const IndicatorConfigView = new Lang.Class({
         {label: 'CoinBase', value: 'coinbase'},
         {label: 'BXinTH',   value: 'bxinth'},
         {label: 'Paymium',  value: 'paymium'},
-        {label: 'BtcChina', value: 'btcchina'}
+        {label: 'BtcChina', value: 'btcchina'},
+        {label: 'Bitso',    value: 'bitso'}
     ];
 
     for each (let o in options) {


### PR DESCRIPTION
[Bitso](https://bitso.com/) is a mexican bitcoin market/exchange. This PR adds the ability to have it's values on the widget, with the advantage of allow MXN currency with apis like BitcoinAvg.