### PR TITLE
Adds support for several altcoins and more

### DIFF
--- a/src/ApiProvider.js
+++ b/src/ApiProvider.js
@@ -9,6 +9,8 @@ const Local = imports.misc.extensionUtils.getCurrentExtension();
 const {
   ProviderBitcoinAverage,
   ProviderBitstamp,
+  ProviderBtce,
+  ProviderPoloniex,
   ProviderCoinbase,
   ProviderBitPay,
   ProviderBXinTH,
@@ -25,6 +27,8 @@ const ApiProvider = new Lang.Class({
     this.apis = {
       bitcoinaverage: new ProviderBitcoinAverage.Api(),
       bitstamp: new ProviderBitstamp.Api(),
+      btce: new ProviderBtce.Api(),
+      poloniex: new ProviderPoloniex.Api(),
       bitpay: new ProviderBitPay.Api(),
       coinbase: new ProviderCoinbase.Api(),
       bxinth: new ProviderBXinTH.Api(),
@@ -56,7 +60,7 @@ if (window["ARGV"] && ARGV[0] === "test") {
 
   let apiProvider = new ApiProvider();
 
-  let options = {currency: "USD", attribute: "last"};
+  let options = {currency: "USD", attribute: "last", coin: "BTC"};
 
   let indicator = apiProvider.get('bitpay', options);
 

--- a/src/BaseProvider.js
+++ b/src/BaseProvider.js
@@ -13,7 +13,7 @@ const { IndicatorModel } = Local.imports.IndicatorModel;
 const DefaultCurrencies = [
       'USD', 'EUR', 'CNY', 'GBP', 'CAD', 'RUB', 'AUD',
       'BRL', 'CZK', 'JPY', 'NZD', 'SEK', 'SGD', 'PLN',
-      'MXN'
+      'MXN', 'RUR'
 ];
 
 const Selector = (path) => {

--- a/src/BaseProvider.js
+++ b/src/BaseProvider.js
@@ -66,9 +66,7 @@ const ChangeRenderer = (options) => {
 
 
 
-const CurrencyRenderer = ({unit, currency, decimals}) => {
-  unit = unit || 'mBTC';
-
+const CurrencyRenderer = ({currency, decimals}) => {
   const getFormat = (currency) => {
     /* determined after mtgox api */
     const front = "%s%v";
@@ -80,14 +78,6 @@ const CurrencyRenderer = ({unit, currency, decimals}) => {
     };
 
     return frontFormats[currency] || back;
-  };
-
-  const changeUnit = (number) => {
-    if (unit === 'mBTC') {
-      return Number(number) / 1000.0;
-    } else {
-      return Number(number);
-    }
   };
 
   let format = getFormat(currency);
@@ -110,7 +100,7 @@ const CurrencyRenderer = ({unit, currency, decimals}) => {
   }
 
   return (number) =>
-    Accounting.formatMoney(changeUnit(number), {
+    Accounting.formatMoney(Number(number), {
       symbol: symbol,
       format: format,
       precision: precision

--- a/src/BaseProvider.js
+++ b/src/BaseProvider.js
@@ -86,12 +86,17 @@ const CurrencyRenderer = ({currency, coin, decimals}) => {
     precision = decimals;
   }
 
-  return (number) =>
-    Accounting.formatMoney(Number(number), {
-      symbol: symbol,
-      format: format,
-      precision: precision
-    }) + "/" + coin;
+  return (number) => {
+    if (coin === 'mBTC') {
+      number = Number(number) / 1000.0;
+    }
+
+    return Accounting.formatMoney(Number(number), {
+        symbol: symbol,
+        format: format,
+        precision: precision
+      }) + "/" + coin;
+  }
 };
 
 

--- a/src/BaseProvider.js
+++ b/src/BaseProvider.js
@@ -66,21 +66,8 @@ const ChangeRenderer = (options) => {
 
 
 
-const CurrencyRenderer = ({currency, decimals}) => {
-  const getFormat = (currency) => {
-    /* determined after mtgox api */
-    const front = "%s%v";
-    const back = "%v %s";
-    const frontFormats = {
-      USD: front, CAD: front, AUD: front, GBP: front,
-      HKD: front, NZD: front, SGD: front, THB: front,
-      MXN: front
-    };
-
-    return frontFormats[currency] || back;
-  };
-
-  let format = getFormat(currency);
+const CurrencyRenderer = ({currency, coin, decimals}) => {
+  let format = "%v %s";
   let symbol = currency;
   let precision = 2;
 
@@ -104,7 +91,7 @@ const CurrencyRenderer = ({currency, decimals}) => {
       symbol: symbol,
       format: format,
       precision: precision
-    });
+    }) + "/" + coin;
 };
 
 

--- a/src/BaseProviderConfigView.js
+++ b/src/BaseProviderConfigView.js
@@ -84,6 +84,14 @@ const makeComboBoxCurrency = (currencies, selected) => {
   return new ComboBoxView(options);
 };
 
+const makeComboBoxCoin = (coins, selected) => {
+  let options = coins.map(
+    (c) => ({label: c, value: c, active: (c === selected)})
+  );
+
+  return new ComboBoxView(options);
+};
+
 
 const BaseProviderConfigView = new Lang.Class({
   Name: "BaseProviderConfigView",
@@ -104,7 +112,6 @@ const BaseProviderConfigView = new Lang.Class({
     return rowWidget;
   },
 
-
   _addSelectCurrency: function (currencies) {
     let comboBoxCurrency = makeComboBoxCurrency(
       currencies, this._indicatorConfig.get('currency')
@@ -115,6 +122,23 @@ const BaseProviderConfigView = new Lang.Class({
     });
 
     let rowWidget = this._addRow(_("Currency"), comboBoxCurrency.widget);
+
+    return {
+      rowWidget: rowWidget,
+      comboBoxView: comboBoxCurrency
+    };
+  },
+
+  _addSelectCoin: function (coins) {
+    let comboBoxCurrency = makeComboBoxCoin(
+      coins, this._indicatorConfig.get('coin')
+    );
+
+    comboBoxCurrency.connect('changed', (view, value) => {
+      this._indicatorConfig.set('coin', value);
+    });
+
+    let rowWidget = this._addRow(_("Coin"), comboBoxCurrency.widget);
 
     return {
       rowWidget: rowWidget,

--- a/src/BaseProviderConfigView.js
+++ b/src/BaseProviderConfigView.js
@@ -77,7 +77,7 @@ Signals.addSignalMethods(ComboBoxView.prototype);
 
 
 const makeComboBoxCurrency = (currencies, selected) => {
-  let options = currencies.map(
+  let options = currencies.sort().map(
     (c) => ({label: c, value: c, active: (c === selected)})
   );
 
@@ -85,7 +85,7 @@ const makeComboBoxCurrency = (currencies, selected) => {
 };
 
 const makeComboBoxCoin = (coins, selected) => {
-  let options = coins.map(
+  let options = coins.sort().map(
     (c) => ({label: c, value: c, active: (c === selected)})
   );
 

--- a/src/CurrencyData.js
+++ b/src/CurrencyData.js
@@ -134,8 +134,8 @@ const CurrencyData = {
         "code": "BRL"
     },
     "BTC": {
-      "symbol": "฿",
-      "symbol_native": "฿",
+      "symbol": "BTC",
+      "symbol_native": "BTC",
       "decimal_digits": 2,
       "rounding": 0,
       "code": "BTC"

--- a/src/CurrencyData.js
+++ b/src/CurrencyData.js
@@ -133,6 +133,13 @@ const CurrencyData = {
         "rounding": 0,
         "code": "BRL"
     },
+    "BTC": {
+      "symbol": "฿",
+      "symbol_native": "฿",
+      "decimal_digits": 2,
+      "rounding": 0,
+      "code": "BTC"
+    },
     "BWP": {
         "symbol": "BWP",
         "symbol_native": "P",
@@ -678,6 +685,13 @@ const CurrencyData = {
         "decimal_digits": 2,
         "rounding": 0,
         "code": "RUB"
+    },
+    "RUR": {
+        "symbol": "RUR",
+        "symbol_native": "руб.",
+        "decimal_digits": 2,
+        "rounding": 0,
+        "code": "RUR"
     },
     "RWF": {
         "symbol": "RWF",

--- a/src/CurrencyData.js
+++ b/src/CurrencyData.js
@@ -681,14 +681,14 @@ const CurrencyData = {
     },
     "RUB": {
         "symbol": "RUB",
-        "symbol_native": "руб.",
+        "symbol_native": "₽",
         "decimal_digits": 2,
         "rounding": 0,
         "code": "RUB"
     },
     "RUR": {
         "symbol": "RUR",
-        "symbol_native": "руб.",
+        "symbol_native": "₽",
         "decimal_digits": 2,
         "rounding": 0,
         "code": "RUR"

--- a/src/IndicatorCollectionModel.js
+++ b/src/IndicatorCollectionModel.js
@@ -110,6 +110,7 @@ const IndicatorCollectionModel = new GObject.Class({
     return {
       api: 'bitcoinaverage',
       currency: 'USD',
+      coin: 'BTC',
       attribute: 'last'
     };
   },

--- a/src/ProviderBXinTH.js
+++ b/src/ProviderBXinTH.js
@@ -12,6 +12,8 @@ const Api = new Lang.Class({
 
   currencies: ['THB'],
 
+  coins: ['BTC','ETH','DAS','REP','GNO'],
+
   interval: 60, // unclear, should be safe
 
   attributes: {
@@ -19,15 +21,29 @@ const Api = new Lang.Class({
       let renderCurrency = BaseProvider.CurrencyRenderer(options);
       let renderChange = BaseProvider.ChangeRenderer();
 
+      let find = (currency, coin, tickerObj) => {
+        let result = {
+          "last_price": 0,
+          "change": 0
+        }
+        Object.keys(tickerObj).forEach((k) => {
+          let current = tickerObj[k];
+          if (current['primary_currency'] === currency && current['secondary_currency'] === coin) {
+            result = current;
+          }
+        });
+        return result;
+      };
+
       return {
-        text: (data) => renderCurrency(data["1"]["last_price"]),
-        change: (data) => renderChange(data["1"]["change"])
+        text: (data) => renderCurrency(find(options.currency, options.coin, data)["last_price"]),
+        change: (data) => renderChange(find(options.currency, options.coin, data)["change"])
       };
     }
   },
 
   getLabel: function (options) {
-    return "BXinTH " + options.currency;
+    return "BXinTH " + options.currency + "/" + options.coin;
   },
 
   getUrl: function (options) {

--- a/src/ProviderBXinTH.js
+++ b/src/ProviderBXinTH.js
@@ -12,16 +12,15 @@ const Api = new Lang.Class({
 
   currencies: ['THB'],
 
-  coins: ['BTC','ETH','DAS','REP','GNO'],
+  coins: ['BTC','mBTC','ETH','DAS','REP','GNO'],//?
 
   interval: 60, // unclear, should be safe
 
   attributes: {
     last: function (options) {
-      let renderCurrency = BaseProvider.CurrencyRenderer(options);
-      let renderChange = BaseProvider.ChangeRenderer();
-
-      let find = (currency, coin, tickerObj) => {
+      const renderCurrency = BaseProvider.CurrencyRenderer(options);
+      const renderChange = BaseProvider.ChangeRenderer();
+      const find = (currency, coin, tickerObj) => {
         let result = {
           "last_price": 0,
           "change": 0
@@ -34,10 +33,11 @@ const Api = new Lang.Class({
         });
         return result;
       };
+      const coin = options.coin === 'mBTC' ? 'BTC' : options.coin;
 
       return {
-        text: (data) => renderCurrency(find(options.currency, options.coin, data)["last_price"]),
-        change: (data) => renderChange(find(options.currency, options.coin, data)["change"])
+        text: (data) => renderCurrency(find(options.currency, coin, data)["last_price"]),
+        change: (data) => renderChange(find(options.currency, coin, data)["change"])
       };
     }
   },

--- a/src/ProviderBXinTHPrefs.js
+++ b/src/ProviderBXinTHPrefs.js
@@ -13,6 +13,7 @@ const ConfigView = new Lang.Class({
   _init: function (configWidget, indicatorConfig) {
     this.parent(configWidget, indicatorConfig);
     this._addSelectCurrency((new ProviderBXinTH.Api()).currencies);
+    this._addSelectCoin((new ProviderBXinTH.Api()).coins);
   },
 
   _setApiDefaults: function (config) {
@@ -20,6 +21,7 @@ const ConfigView = new Lang.Class({
       config.attributes = {
         api: 'bxinth',
         currency: 'THB',
+        coin: 'BTC',
         attribute: 'last'
       };
 

--- a/src/ProviderBitPay.js
+++ b/src/ProviderBitPay.js
@@ -12,16 +12,15 @@ const Api = new Lang.Class({
 
   currencies: BaseProvider.DefaultCurrencies,
 
-  coins: ['BTC'],
+  coins: ['BTC','mBTC'],
 
   interval: 60, // unclear, should be safe
 
   attributes: {
     last: function (options) {
-      let renderCurrency = BaseProvider.CurrencyRenderer(options);
-      let renderChange = BaseProvider.ChangeRenderer();
-
-      let find = (currency, arr) => {
+      const renderCurrency = BaseProvider.CurrencyRenderer(options);
+      const renderChange = BaseProvider.ChangeRenderer();
+      const find = (currency, arr) => {
         for (let {code, rate} of arr) {
           if (code === currency) {
             return rate;

--- a/src/ProviderBitPay.js
+++ b/src/ProviderBitPay.js
@@ -12,6 +12,8 @@ const Api = new Lang.Class({
 
   currencies: BaseProvider.DefaultCurrencies,
 
+  coins: ['BTC'],
+
   interval: 60, // unclear, should be safe
 
   attributes: {
@@ -37,7 +39,7 @@ const Api = new Lang.Class({
   },
 
   getLabel: function (options) {
-    return "BitPay " + options.currency;
+    return "BitPay " + options.currency + "/" + options.coin;
   },
 
   getUrl: function (options) {

--- a/src/ProviderBitPayPrefs.js
+++ b/src/ProviderBitPayPrefs.js
@@ -13,6 +13,7 @@ const ConfigView = new Lang.Class({
   _init: function (configWidget, indicatorConfig) {
     this.parent(configWidget, indicatorConfig);
     this._addSelectCurrency((new ProviderBitPay.Api()).currencies);
+    this._addSelectCoin((new ProviderBitPay.Api()).coins);
   },
 
   _setApiDefaults: function (config) {
@@ -20,6 +21,7 @@ const ConfigView = new Lang.Class({
       config.attributes = {
         api: 'bitpay',
         currency: 'USD',
+        coin: 'BTC',
         attribute: 'last'
       };
 

--- a/src/ProviderBitcoinAverage.js
+++ b/src/ProviderBitcoinAverage.js
@@ -29,6 +29,9 @@ const Api = new Lang.Class({
   exchanges: Object.keys(getExchangeToCurrency()),
 
   currencies: BaseProvider.DefaultCurrencies,
+
+  coins: ['BTC'],
+
   /* quote https://bitcoinaverage.com/api.htm
    *
    * > API is updated along with the site, normally around every minute. There
@@ -71,9 +74,9 @@ const Api = new Lang.Class({
 
   getLabel: function (options) {
     if (options.use_average !== false) {
-      return "BitAvg " + options.currency;
+      return "BitAvg " + options.currency + "/" + options.coin;
     } else if (options.exchange !== undefined) {
-      return "BitAvg " + options.currency + "@" + options.exchange;
+      return "BitAvg " + options.currency + "/" + options.coin + "@" + options.exchange;
     } else {
       throw _invalidExchangeError();
     }

--- a/src/ProviderBitcoinAverage.js
+++ b/src/ProviderBitcoinAverage.js
@@ -30,7 +30,7 @@ const Api = new Lang.Class({
 
   currencies: BaseProvider.DefaultCurrencies,
 
-  coins: ['BTC'],
+  coins: ['BTC','mBTC'],
 
   /* quote https://bitcoinaverage.com/api.htm
    *
@@ -42,10 +42,9 @@ const Api = new Lang.Class({
 
   attributes: {
     last: (options) => {
-      let renderCurrency = BaseProvider.CurrencyRenderer(options);
-      let renderChange = BaseProvider.ChangeRenderer();
-
-      let getNumber = (data) => {
+      const renderCurrency = BaseProvider.CurrencyRenderer(options);
+      const renderChange = BaseProvider.ChangeRenderer();
+      const getNumber = (data) => {
         if (options.use_average !== false) {
           return data.last;
         } else if (options.exchange !== undefined) {

--- a/src/ProviderBitcoinAveragePrefs.js
+++ b/src/ProviderBitcoinAveragePrefs.js
@@ -40,6 +40,8 @@ const ConfigView = new Lang.Class({
       );
     };
 
+    this._addSelectCoin(api.coins);
+
     let currencySelect = this._addSelectCurrency(api.currencies);
     currencySelect.comboBoxView.connect('changed', updateExchangeSelect);
 
@@ -52,7 +54,6 @@ const ConfigView = new Lang.Class({
     });
 
     /* exchange selection */
-
     let exchangeSelect = this._addSelectExchange();
     updateExchangeSelect();
   },
@@ -106,6 +107,7 @@ const ConfigView = new Lang.Class({
         api: 'bitcoinaverage',
         exchange: 'average',
         currency: 'USD',
+        coin: 'BTC',
         attribute: 'last'
       };
 

--- a/src/ProviderBitcoinAveragePrefs.js
+++ b/src/ProviderBitcoinAveragePrefs.js
@@ -40,10 +40,10 @@ const ConfigView = new Lang.Class({
       );
     };
 
-    this._addSelectCoin(api.coins);
-
     let currencySelect = this._addSelectCurrency(api.currencies);
     currencySelect.comboBoxView.connect('changed', updateExchangeSelect);
+
+    this._addSelectCoin(api.coins);
 
     /* use average switch */
     // TODO use proper view method: connect("changed")

--- a/src/ProviderBitso.js
+++ b/src/ProviderBitso.js
@@ -12,7 +12,7 @@ const Api = new Lang.Class({
 
   currencies: ['MXN'],
 
-  coins: ['BTC','ETH'],
+  coins: ['BTC','mBTC','ETH'],
 
   /* quote https://bitso.com/api_info#rate-limits
    *
@@ -23,8 +23,8 @@ const Api = new Lang.Class({
 
   attributes: {
     last: function (options) {
-      let renderCurrency = BaseProvider.CurrencyRenderer(options);
-      let renderChange = BaseProvider.ChangeRenderer();
+      const renderCurrency = BaseProvider.CurrencyRenderer(options);
+      const renderChange = BaseProvider.ChangeRenderer();
 
       return {
         text: (data) => renderCurrency(data.last),
@@ -38,6 +38,7 @@ const Api = new Lang.Class({
   },
 
   getUrl: function(options) {
-    return "https://api.bitso.com/v2/ticker?book=" + options.coin + "_" + options.currency;
+    const coin = options.coin === 'mBTC' ? 'BTC' : options.coin;
+    return "https://api.bitso.com/v2/ticker?book=" + coin + "_" + options.currency;
   }
 });

--- a/src/ProviderBitso.js
+++ b/src/ProviderBitso.js
@@ -12,6 +12,8 @@ const Api = new Lang.Class({
 
   currencies: ['MXN'],
 
+  coins: ['BTC','ETH'],
+
   /* quote https://bitso.com/api_info#rate-limits
    *
    * > Rate limits are are based on one minute windows. If you do more than 30
@@ -32,10 +34,10 @@ const Api = new Lang.Class({
   },
 
   getLabel: function(options) {
-    return "Bitso " + options.currency;
+    return "Bitso " + options.currency + "/" + options.coin;
   },
 
   getUrl: function(options) {
-    return "https://api.bitso.com/v2/ticker";
+    return "https://api.bitso.com/v2/ticker?book=" + options.coin + "_" + options.currency;
   }
 });

--- a/src/ProviderBitsoPrefs.js
+++ b/src/ProviderBitsoPrefs.js
@@ -13,6 +13,7 @@ const ConfigView = new Lang.Class({
   _init: function (configWidget, indicatorConfig) {
     this.parent(configWidget, indicatorConfig);
     this._addSelectCurrency((new ProviderBitso.Api()).currencies);
+    this._addSelectCoin((new ProviderBitso.Api()).coins);
   },
 
   _setApiDefaults: function (config) {
@@ -20,6 +21,7 @@ const ConfigView = new Lang.Class({
       config.attributes = {
         api: 'bitso',
         currency: 'MXN',
+        coin: 'BTC',
         attribute: 'last'
       };
 

--- a/src/ProviderBitstamp.js
+++ b/src/ProviderBitstamp.js
@@ -15,14 +15,14 @@ const Api = new Lang.Class({
 
   currencies: ['USD', 'EUR'],
 
-  coins: ['BTC','XRP'],
+  coins: ['BTC','mBTC','XRP'],
 
   interval: 10, // 60 requests per 10 minutes
 
   attributes: {
     last: function (options) {
-      let renderCurrency = BaseProvider.CurrencyRenderer(options);
-      let renderChange = BaseProvider.ChangeRenderer();
+      const renderCurrency = BaseProvider.CurrencyRenderer(options);
+      const renderChange = BaseProvider.ChangeRenderer();
 
       return {
         text: (data) => renderCurrency(data.last),
@@ -36,7 +36,8 @@ const Api = new Lang.Class({
   },
 
   getUrl: function (options) {
+    const coin = options.coin === 'mBTC' ? 'BTC' : options.coin;
     return "https://www.bitstamp.net/api/v2/ticker/" +
-      options.coin.toLowerCase() + options.currency.toLowerCase() + '/';
+      coin.toLowerCase() + options.currency.toLowerCase() + '/';
   }
 });

--- a/src/ProviderBitstamp.js
+++ b/src/ProviderBitstamp.js
@@ -15,6 +15,8 @@ const Api = new Lang.Class({
 
   currencies: ['USD', 'EUR'],
 
+  coins: ['BTC','XRP'],
+
   interval: 10, // 60 requests per 10 minutes
 
   attributes: {
@@ -30,11 +32,11 @@ const Api = new Lang.Class({
   },
 
   getLabel: function (options) {
-    return "BitStamp " + options.currency;
+    return "BitStamp " + options.currency + "/" + options.coin;
   },
 
   getUrl: function (options) {
     return "https://www.bitstamp.net/api/v2/ticker/" +
-      'btc' + options.currency.toLowerCase() + '/';
+      options.coin.toLowerCase() + options.currency.toLowerCase() + '/';
   }
 });

--- a/src/ProviderBitstampPrefs.js
+++ b/src/ProviderBitstampPrefs.js
@@ -20,7 +20,7 @@ const ConfigView = new Lang.Class({
     if (config.get('api') !== 'bitstamp') {
       config.attributes = {
         api: 'bitstamp',
-        currency: 'EUR',
+        currency: 'USD',
         coin: 'BTC',
         attribute: 'last'
       };

--- a/src/ProviderBitstampPrefs.js
+++ b/src/ProviderBitstampPrefs.js
@@ -13,13 +13,15 @@ const ConfigView = new Lang.Class({
   _init: function (configWidget, indicatorConfig) {
     this.parent(configWidget, indicatorConfig);
     this._addSelectCurrency((new ProviderBitstamp.Api()).currencies);
+    this._addSelectCoin((new ProviderBitstamp.Api()).coins);
   },
 
   _setApiDefaults: function (config) {
     if (config.get('api') !== 'bitstamp') {
       config.attributes = {
         api: 'bitstamp',
-        currency: 'USD',
+        currency: 'EUR',
+        coin: 'BTC',
         attribute: 'last'
       };
 

--- a/src/ProviderBtcChina.js
+++ b/src/ProviderBtcChina.js
@@ -12,14 +12,14 @@ const Api = new Lang.Class({
 
   currencies: ['CNY'],
 
-  coins: ['BTC','LTC'],
+  coins: ['BTC','mBTC','LTC'],
 
   interval: 10,
 
   attributes: {
     last: function (options) {
-      let renderCurrency = BaseProvider.CurrencyRenderer(options);
-      let renderChange = BaseProvider.ChangeRenderer();
+      const renderCurrency = BaseProvider.CurrencyRenderer(options);
+      const renderChange = BaseProvider.ChangeRenderer();
 
       return {
         text: (data) => renderCurrency(data["ticker"]["last"]),
@@ -33,6 +33,7 @@ const Api = new Lang.Class({
   },
 
   getUrl: function (options) {
-    return "https://data.btcchina.com/data/ticker?market=" + options.currency.toLowerCase() + options.coin.toLowerCase();
+    const coin = options.coin === 'mBTC' ? 'BTC' : options.coin;
+    return "https://data.btcchina.com/data/ticker?market=" + options.currency.toLowerCase() + coin.toLowerCase();
   }
 });

--- a/src/ProviderBtcChina.js
+++ b/src/ProviderBtcChina.js
@@ -12,6 +12,8 @@ const Api = new Lang.Class({
 
   currencies: ['CNY'],
 
+  coins: ['BTC','LTC'],
+
   interval: 10,
 
   attributes: {
@@ -27,10 +29,10 @@ const Api = new Lang.Class({
   },
 
   getLabel: function (options) {
-    return "BTCC " + options.currency;
+    return "BTCC " + options.currency + "/" + options.coin;
   },
 
   getUrl: function (options) {
-    return "https://data.btcchina.com/data/ticker?market=btccny";
+    return "https://data.btcchina.com/data/ticker?market=" + options.currency.toLowerCase() + options.coin.toLowerCase();
   }
 });

--- a/src/ProviderBtcChinaPrefs.js
+++ b/src/ProviderBtcChinaPrefs.js
@@ -13,6 +13,7 @@ const ConfigView = new Lang.Class({
   _init: function (configWidget, indicatorConfig) {
     this.parent(configWidget, indicatorConfig);
     this._addSelectCurrency((new ProviderBtcChina.Api()).currencies);
+    this._addSelectCoin((new ProviderBtcChina.Api()).coins);
   },
 
   _setApiDefaults: function (config) {
@@ -20,6 +21,7 @@ const ConfigView = new Lang.Class({
       config.attributes = {
         api: 'btcchina',
         currency: 'CNY',
+        coin: 'BTC',
         attribute: 'last'
       };
 

--- a/src/ProviderBtce.js
+++ b/src/ProviderBtce.js
@@ -1,0 +1,42 @@
+const Lang = imports.lang;
+
+const Local = imports.misc.extensionUtils.getCurrentExtension();
+const BaseProvider = Local.imports.BaseProvider;
+
+
+const Api = new Lang.Class({
+  Name: 'Btce.Api',
+  Extends: BaseProvider.Api,
+
+  apiName: "Btce",
+
+  currencies: ['USD', 'EUR', 'RUR'],
+
+  coins: ['BTC','LTC','NMC','NVC','PPC','DSH','ETH'],
+
+  interval: 10, // 60 requests per 10 minutes
+
+  attributes: {
+    last: function (options) {
+      let renderCurrency = BaseProvider.CurrencyRenderer(options);
+      let renderChange = BaseProvider.ChangeRenderer();
+
+      let find = (currency, coin, tickerObj) => {
+        return tickerObj[coin.toLowerCase() + '_' + currency.toLowerCase()] || { "last": 0 };
+      };
+
+      return {
+        text: (data) => renderCurrency(find(options.currency, options.coin, data).last),
+        change: (data) => renderChange(find(options.currency, options.coin, data).last)
+      };
+    }
+  },
+
+  getLabel: function (options) {
+    return "BTC-E " + options.currency + "/" + options.coin;
+  },
+
+  getUrl: function (options) {
+    return "https://btc-e.com/api/3/ticker/" + options.coin.toLowerCase() + "_" + options.currency.toLowerCase();
+  }
+});

--- a/src/ProviderBtce.js
+++ b/src/ProviderBtce.js
@@ -12,22 +12,22 @@ const Api = new Lang.Class({
 
   currencies: ['USD', 'EUR', 'RUR'],
 
-  coins: ['BTC','LTC','NMC','NVC','PPC','DSH','ETH'],
+  coins: ['BTC','mBTC','LTC','NMC','NVC','PPC','DSH','ETH'],
 
   interval: 10, // 60 requests per 10 minutes
 
   attributes: {
     last: function (options) {
-      let renderCurrency = BaseProvider.CurrencyRenderer(options);
-      let renderChange = BaseProvider.ChangeRenderer();
-
-      let find = (currency, coin, tickerObj) => {
+      const renderCurrency = BaseProvider.CurrencyRenderer(options);
+      const renderChange = BaseProvider.ChangeRenderer();
+      const find = (currency, coin, tickerObj) => {
         return tickerObj[coin.toLowerCase() + '_' + currency.toLowerCase()] || { "last": 0 };
       };
+      const coin = options.coin === 'mBTC' ? 'BTC' : options.coin;
 
       return {
-        text: (data) => renderCurrency(find(options.currency, options.coin, data).last),
-        change: (data) => renderChange(find(options.currency, options.coin, data).last)
+        text: (data) => renderCurrency(find(options.currency, coin, data).last),
+        change: (data) => renderChange(find(options.currency, coin, data).last)
       };
     }
   },
@@ -37,6 +37,7 @@ const Api = new Lang.Class({
   },
 
   getUrl: function (options) {
-    return "https://btc-e.com/api/3/ticker/" + options.coin.toLowerCase() + "_" + options.currency.toLowerCase();
+    const coin = options.coin === 'mBTC' ? 'BTC' : options.coin;
+    return "https://btc-e.com/api/3/ticker/" + coin.toLowerCase() + "_" + options.currency.toLowerCase();
   }
 });

--- a/src/ProviderBtcePrefs.js
+++ b/src/ProviderBtcePrefs.js
@@ -1,0 +1,33 @@
+const Lang = imports.lang;
+const Signals = imports.signals;
+
+const Local = imports.misc.extensionUtils.getCurrentExtension();
+const { ProviderBtce } = Local.imports;
+const { BaseProviderConfigView } = Local.imports.BaseProviderConfigView;
+
+
+const ConfigView = new Lang.Class({
+  Name: "ProviderBtce.ConfigView",
+  Extends: BaseProviderConfigView,
+
+  _init: function (configWidget, indicatorConfig) {
+    this.parent(configWidget, indicatorConfig);
+    this._addSelectCurrency((new ProviderBtce.Api()).currencies);
+    this._addSelectCoin((new ProviderBtce.Api()).coins);
+  },
+
+  _setApiDefaults: function (config) {
+    if (config.get('api') !== 'btce') {
+      config.attributes = {
+        api: 'btce',
+        currency: 'USD',
+        coin: 'BTC',
+        attribute: 'last'
+      };
+
+      config.emit('update');
+    }
+  },
+});
+Signals.addSignalMethods(ConfigView.prototype);
+

--- a/src/ProviderCoinbase.js
+++ b/src/ProviderCoinbase.js
@@ -12,16 +12,16 @@ const Api = new Lang.Class({
 
   currencies: BaseProvider.DefaultCurrencies,
 
-  coins: ['BTC','LTC','ETH'],
+  coins: ['BTC','mBTC','LTC','ETH'],
 
   interval: 60, // unclear, should be safe
 
   attributes: {
     last: function (options) {
-      let renderCurrency = BaseProvider.CurrencyRenderer(options);
-      let renderChange = BaseProvider.ChangeRenderer();
-
-      let key = options.coin.toLowerCase() + '_to_' + options.currency.toLowerCase();
+      const renderCurrency = BaseProvider.CurrencyRenderer(options);
+      const renderChange = BaseProvider.ChangeRenderer();
+      const coin = options.coin === 'mBTC' ? 'BTC' : options.coin;
+      const key = coin.toLowerCase() + '_to_' + options.currency.toLowerCase();
 
       return {
         text: (data) => renderCurrency(data[key]),

--- a/src/ProviderCoinbase.js
+++ b/src/ProviderCoinbase.js
@@ -12,6 +12,8 @@ const Api = new Lang.Class({
 
   currencies: BaseProvider.DefaultCurrencies,
 
+  coins: ['BTC','LTC','ETH'],
+
   interval: 60, // unclear, should be safe
 
   attributes: {
@@ -19,7 +21,7 @@ const Api = new Lang.Class({
       let renderCurrency = BaseProvider.CurrencyRenderer(options);
       let renderChange = BaseProvider.ChangeRenderer();
 
-      let key = 'btc_to_' + options.currency.toLowerCase();
+      let key = options.coin.toLowerCase() + '_to_' + options.currency.toLowerCase();
 
       return {
         text: (data) => renderCurrency(data[key]),
@@ -29,7 +31,7 @@ const Api = new Lang.Class({
   },
 
   getLabel: function (options) {
-    return "Coinbase " + options.currency;
+    return "Coinbase " + options.currency + "/" + options.coin;
   },
 
   getUrl: function (options) {

--- a/src/ProviderCoinbasePrefs.js
+++ b/src/ProviderCoinbasePrefs.js
@@ -13,6 +13,7 @@ const ConfigView = new Lang.Class({
   _init: function (configWidget, indicatorConfig) {
     this.parent(configWidget, indicatorConfig);
     this._addSelectCurrency((new ProviderCoinbase.Api()).currencies);
+    this._addSelectCoin((new ProviderCoinbase.Api()).coins);
   },
 
   _setApiDefaults: function (config) {
@@ -20,6 +21,7 @@ const ConfigView = new Lang.Class({
       config.attributes = {
         api: 'coinbase',
         currency: 'USD',
+        coin: 'BTC',
         attribute: 'last'
       };
 

--- a/src/ProviderPaymium.js
+++ b/src/ProviderPaymium.js
@@ -12,14 +12,14 @@ const Api = new Lang.Class({
 
   currencies: ['EUR'],
 
-  coins: ['BTC'],
+  coins: ['BTC','mBTC'],
 
   interval: 60, // unclear, should be safe
 
   attributes: {
     last: function (options) {
-      let renderCurrency = BaseProvider.CurrencyRenderer(options);
-      let renderChange = BaseProvider.ChangeRenderer();
+      const renderCurrency = BaseProvider.CurrencyRenderer(options);
+      const renderChange = BaseProvider.ChangeRenderer();
 
       return {
         text: (data) => renderCurrency(data["price"]),

--- a/src/ProviderPaymium.js
+++ b/src/ProviderPaymium.js
@@ -12,6 +12,8 @@ const Api = new Lang.Class({
 
   currencies: ['EUR'],
 
+  coins: ['BTC'],
+
   interval: 60, // unclear, should be safe
 
   attributes: {
@@ -27,10 +29,10 @@ const Api = new Lang.Class({
   },
 
   getLabel: function (options) {
-    return "Paymium " + options.currency;
+    return "Paymium " + options.currency + "/" + options.coin;
   },
 
   getUrl: function (options) {
-    return "https://paymium.com/api/v1/data/eur/ticker";
+    return "https://paymium.com/api/v1/data/" + options.currency.toLowerCase() + "/ticker";
   }
 });

--- a/src/ProviderPaymiumPrefs.js
+++ b/src/ProviderPaymiumPrefs.js
@@ -13,6 +13,7 @@ const ConfigView = new Lang.Class({
   _init: function (configWidget, indicatorConfig) {
     this.parent(configWidget, indicatorConfig);
     this._addSelectCurrency((new ProviderPaymium.Api()).currencies);
+    this._addSelectCoin((new ProviderPaymium.Api()).coins);
   },
 
   _setApiDefaults: function (config) {
@@ -20,6 +21,7 @@ const ConfigView = new Lang.Class({
       config.attributes = {
         api: 'paymium',
         currency: 'EUR',
+        coin: 'BTC',
         attribute: 'last'
       };
 

--- a/src/ProviderPoloniex.js
+++ b/src/ProviderPoloniex.js
@@ -10,9 +10,9 @@ const Api = new Lang.Class({
 
   apiName: "Poloniex",
 
-  currencies: ['BTC','USD'],
+  currencies: ['USD'],
 
-  coins: ['BCN', 'BELA','BLK','BTCD','BTM','BTS','BURST','CLAM','DASH','DGB','DOGE','EMC2','FLDC','FLO','GAME',
+  coins: ['BTC','mBTC','BCN', 'BELA','BLK','BTCD','BTM','BTS','BURST','CLAM','DASH','DGB','DOGE','EMC2','FLDC','FLO','GAME',
     'GRC','HUC','LTC','MAID','OMNI','NAUT','NAV','NEOS','NMC','NOTE','NXT','PINK','POT','PPC','RIC','SJCX','STR',
     'SYS','VIA','XVC','VRC','VTC','XBC','XCP','XEM','XMR','XPM','XRP','ETH','SC','BCY','EXP','FCT','RADS','AMP',
     'DCR','LSK','LBC','STEEM','SBD','ETC','REP','ARDR','ZEC','STRAT','NXC','PASC','GNT','GNO'],
@@ -21,17 +21,20 @@ const Api = new Lang.Class({
 
   attributes: {
     last: function (options) {
-      let renderCurrency = BaseProvider.CurrencyRenderer(options);
-      let renderChange = BaseProvider.ChangeRenderer();
-
-      let find = (currency, coin, tickerObj) => {
+      const renderCurrency = BaseProvider.CurrencyRenderer(options);
+      const renderChange = BaseProvider.ChangeRenderer();
+      const find = (currency, coin, tickerObj) => {
         // The Poloniex ticker only offers BTC prices
         // Wen USD is selected, do a conversion using the USDt price
         let coinPrice;
         try {
           if (currency === 'USD') {
             let btcUsdtPrice = tickerObj['USDT_BTC'].last;
-            coinPrice = tickerObj['BTC_' + coin].last * btcUsdtPrice;
+            if (coin === 'BTC') {
+              coinPrice = btcUsdtPrice
+            } else {
+              coinPrice = tickerObj['BTC_' + coin].last * btcUsdtPrice;
+            }
           } else {
             coinPrice = tickerObj[currency + '_' + coin].last;
           }
@@ -40,10 +43,11 @@ const Api = new Lang.Class({
         }
         return coinPrice;
       };
+      const coin = options.coin === 'mBTC' ? 'BTC' : options.coin;
 
       return {
-        text: (data) => renderCurrency(find(options.currency, options.coin, data)),
-        change: (data) => renderChange(find(options.currency, options.coin, data))
+        text: (data) => renderCurrency(find(options.currency, coin, data)),
+        change: (data) => renderChange(find(options.currency, coin, data))
       };
     }
   },

--- a/src/ProviderPoloniex.js
+++ b/src/ProviderPoloniex.js
@@ -1,0 +1,61 @@
+const Lang = imports.lang;
+
+const Local = imports.misc.extensionUtils.getCurrentExtension();
+const BaseProvider = Local.imports.BaseProvider;
+
+
+const Api = new Lang.Class({
+  Name: 'Poloniex.Api',
+  Extends: BaseProvider.Api,
+
+  apiName: "Poloniex",
+
+  currencies: ['BTC','USD'],
+
+  coins: ['BCN', 'BELA','BLK','BTCD','BTM','BTS','BURST','CLAM','DASH','DGB','DOGE','EMC2','FLDC','FLO','GAME',
+    'GRC','HUC','LTC','MAID','OMNI','NAUT','NAV','NEOS','NMC','NOTE','NXT','PINK','POT','PPC','RIC','SJCX','STR',
+    'SYS','VIA','XVC','VRC','VTC','XBC','XCP','XEM','XMR','XPM','XRP','ETH','SC','BCY','EXP','FCT','RADS','AMP',
+    'DCR','LSK','LBC','STEEM','SBD','ETC','REP','ARDR','ZEC','STRAT','NXC','PASC','GNT','GNO'],
+
+  interval: 10, // 60 requests per 10 minutes
+
+  attributes: {
+    last: function (options) {
+      let renderCurrency = BaseProvider.CurrencyRenderer(options);
+      let renderChange = BaseProvider.ChangeRenderer();
+
+      let find = (currency, coin, tickerObj) => {
+        global.log(JSON.stringify(tickerObj), currency, coin)
+
+        // The Poloniex ticker only offers BTC prices
+        // Wen USD is selected, do a conversion using the USDt price
+        let coinPrice;
+        try {
+          if (currency === 'USD') {
+            let btcUsdtPrice = tickerObj['USDT_BTC'].last;
+            coinPrice = tickerObj['BTC_' + coin].last * btcUsdtPrice;
+            global.log(btcUsdtPrice)
+          } else {
+            coinPrice = tickerObj[currency + '_' + coin].last;
+          }
+        } catch (e) {
+          return 0;
+        }
+        return coinPrice;
+      };
+
+      return {
+        text: (data) => renderCurrency(find(options.currency, options.coin, data)),
+        change: (data) => renderChange(find(options.currency, options.coin, data))
+      };
+    }
+  },
+
+  getLabel: function (options) {
+    return "Poloniex " + options.currency + "/" + options.coin;
+  },
+
+  getUrl: function (options) {
+    return "https://poloniex.com/public?command=returnTicker";
+  }
+});

--- a/src/ProviderPoloniex.js
+++ b/src/ProviderPoloniex.js
@@ -25,8 +25,6 @@ const Api = new Lang.Class({
       let renderChange = BaseProvider.ChangeRenderer();
 
       let find = (currency, coin, tickerObj) => {
-        global.log(JSON.stringify(tickerObj), currency, coin)
-
         // The Poloniex ticker only offers BTC prices
         // Wen USD is selected, do a conversion using the USDt price
         let coinPrice;
@@ -34,7 +32,6 @@ const Api = new Lang.Class({
           if (currency === 'USD') {
             let btcUsdtPrice = tickerObj['USDT_BTC'].last;
             coinPrice = tickerObj['BTC_' + coin].last * btcUsdtPrice;
-            global.log(btcUsdtPrice)
           } else {
             coinPrice = tickerObj[currency + '_' + coin].last;
           }

--- a/src/ProviderPoloniexPrefs.js
+++ b/src/ProviderPoloniexPrefs.js
@@ -1,0 +1,33 @@
+const Lang = imports.lang;
+const Signals = imports.signals;
+
+const Local = imports.misc.extensionUtils.getCurrentExtension();
+const { ProviderPoloniex } = Local.imports;
+const { BaseProviderConfigView } = Local.imports.BaseProviderConfigView;
+
+
+const ConfigView = new Lang.Class({
+  Name: "ProviderPoloniex.ConfigView",
+  Extends: BaseProviderConfigView,
+
+  _init: function (configWidget, indicatorConfig) {
+    this.parent(configWidget, indicatorConfig);
+    this._addSelectCurrency((new ProviderPoloniex.Api()).currencies);
+    this._addSelectCoin((new ProviderPoloniex.Api()).coins);
+  },
+
+  _setApiDefaults: function (config) {
+    if (config.get('api') !== 'poloniex') {
+      config.attributes = {
+        api: 'poloniex',
+        currency: 'BTC',
+        coin: 'BTC',
+        attribute: 'last'
+      };
+
+      config.emit('update');
+    }
+  },
+});
+Signals.addSignalMethods(ConfigView.prototype);
+

--- a/src/ProviderPoloniexPrefs.js
+++ b/src/ProviderPoloniexPrefs.js
@@ -20,7 +20,7 @@ const ConfigView = new Lang.Class({
     if (config.get('api') !== 'poloniex') {
       config.attributes = {
         api: 'poloniex',
-        currency: 'BTC',
+        currency: 'USD',
         coin: 'BTC',
         attribute: 'last'
       };

--- a/src/extension.js
+++ b/src/extension.js
@@ -46,6 +46,7 @@ const _Defaults = [
   {
     api: 'bitcoinaverage',
     currency: 'USD',
+    coin: 'BTC',
     attribute: 'last'
   }
 ];

--- a/src/metadata.json.in
+++ b/src/metadata.json.in
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.22", "3.24"],
+    "shell-version": ["3.20", "3.22", "3.24"],
     "uuid": "bitcoin-markets@ottoallmendinger.github.com",
     "name": "Bitcoin Markets",
     "url": "https://github.com/OttoAllmendinger/gnome-shell-bitcoin-markets/",

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -87,8 +87,6 @@ const IndicatorConfigView = new Lang.Class({
 
   _addIndicatorSettings: function () {
     var layout = this._layoutIndicatorSettings;
-
-    layout.add(this._confSelectUnit());
     layout.add(this._confDecimals());
     layout.add(this._confShowChange());
     layout.add(this._confProvider());
@@ -156,27 +154,6 @@ const IndicatorConfigView = new Lang.Class({
     view.connect("changed", (view, api) => this._selectApi(api));
 
     return makeConfigRow(_("Provider"), view.widget);
-  },
-
-  _confSelectUnit: function () {
-    let preset = this._indicatorConfig.get('unit') || 'mBTC';
-
-    let unitView = new ComboBoxView([
-      {label: 'mBTC', value: 'mBTC', active: (preset === 'mBTC')},
-      {label: 'BTC',  value: 'BTC',  active: (preset === 'BTC')}
-    ]);
-
-    if (this._indicatorConfig.get('unit') === undefined) {
-      this._indicatorConfig.set('unit', 'mBTC');
-    }
-
-    unitView.connect('changed', (view, value) => {
-      this._indicatorConfig.set('unit', value);
-    });
-
-    let rowWidget = makeConfigRow(_("Unit"), unitView.widget);
-
-    return rowWidget;
   },
 
   _confShowChange: function () {

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -18,6 +18,8 @@ const ApiProvider = Local.imports.ApiProvider;
 const {
   ProviderBitcoinAverage,
   ProviderBitstamp,
+  ProviderBtce,
+  ProviderPoloniex,
   ProviderCoinbase,
   ProviderBitPay,
   ProviderBXinTH,
@@ -28,6 +30,8 @@ const {
 const {
   ProviderBitcoinAveragePrefs,
   ProviderBitstampPrefs,
+  ProviderBtcePrefs,
+  ProviderPoloniexPrefs,
   ProviderCoinbasePrefs,
   ProviderBitPayPrefs,
   ProviderBXinTHPrefs,
@@ -99,6 +103,10 @@ const IndicatorConfigView = new Lang.Class({
     let apiConfigViews = {
       bitstamp: () =>
         new ProviderBitstampPrefs.ConfigView(widget, config),
+      btce: () =>
+        new ProviderBtcePrefs.ConfigView(widget, config),
+      poloniex: () =>
+        new ProviderPoloniexPrefs.ConfigView(widget, config),
       bitcoinaverage: () =>
         new ProviderBitcoinAveragePrefs.ConfigView(widget, config),
       bitpay: () =>
@@ -135,6 +143,8 @@ const IndicatorConfigView = new Lang.Class({
     let options = [
         {label: 'BitcoinAverage', value: 'bitcoinaverage'},
         {label: 'BitStamp', value: 'bitstamp'},
+        {label: 'BTC-E', value: 'btce'},
+        {label: 'Poloniex', value: 'poloniex'},
         {label: 'BitPay',   value: 'bitpay'},
         {label: 'CoinBase', value: 'coinbase'},
         {label: 'BXinTH',   value: 'bxinth'},


### PR DESCRIPTION
Hi! Thanks for the great Gnome Shell Bitcoin extension. I've made some changes on a fork that you'd might want to merge into your master.

Functionality:
* Altcoins support for the existing providers
* Adds BTC-E and Poloniex providers
* Removes "Unit" from indicator settings, mBTC didn't make sense together with altcoins
* Changes format of indicator to include currency plus chosen coin
* Adds support for older version of Gnome shell (3.20)

I've also been thinking about adding an amount field to the Provider dialog that you can use to fill in how much of a certain coin you have. This would allow you to see the value of your portfolio in a glance. Let me know if this is something you would like to merge.