### PR TITLE
add Omise GO (THB/OMG) in BXinTH.Api

### DIFF
--- a/src/ProviderBXinTH.js
+++ b/src/ProviderBXinTH.js
@@ -12,7 +12,7 @@ const Api = new Lang.Class({
 
   currencies: ['THB'],
 
-  coins: ['BTC','mBTC','ETH','DAS','REP','GNO'],//?
+  coins: ['BTC','mBTC','ETH','DAS','REP','GNO', 'OMG'],//?
 
   interval: 60, // unclear, should be safe
 


### PR DESCRIPTION
```Omise Go``` is popular in Thailand and is currently getting popular. Added it to the list so we get the fresh value in the gnome shell extensions.