### PR TITLE
Add gnome version 3.18 to metadata

### DIFF
--- a/src/metadata.json.in
+++ b/src/metadata.json.in
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.20", "3.22", "3.24", "3.26"],
+    "shell-version": ["3.18", "3.20", "3.22", "3.24", "3.26"],
     "uuid": "bitcoin-markets@ottoallmendinger.github.com",
     "name": "Bitcoin Markets",
     "url": "https://github.com/OttoAllmendinger/gnome-shell-bitcoin-markets/",


### PR DESCRIPTION
Ubuntu 16.04 ships with ```gnome-shell``` version of ```3.18.5``` so it makes sense to have it supported.