### PR TITLE
Add Satang.pro support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ On most systems you can use `journalctl /usr/bin/gnome-shell -f` to get log outp
 * https://github.com/volandku - BitMEX support
 * https://github.com/HawtDogFlvrWtr - CryptoCompare support
 * https://github.com/jpereira - Blinktrade support
+* https://github.com/rossigee - BX.in.th and Satang.pro support
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Available APIs:
 * Kraken
 * Paymium
 * Poloniex
+* Satang.pro
 
 
 ## Installation

--- a/src/ApiService.js
+++ b/src/ApiService.js
@@ -27,6 +27,7 @@ const {
   ProviderKraken,
   ProviderPaymium,
   ProviderPoloniex,
+  ProviderSatangPro,
 } = Local.imports;
 
 const Providers = {
@@ -48,6 +49,7 @@ const Providers = {
   kraken: new ProviderKraken.Api(),
   paymium: new ProviderPaymium.Api(),
   poloniex: new ProviderPoloniex.Api(),
+  satangpro: new ProviderSatangPro.Api(),
 };
 
 const getProvider = (name) => {

--- a/src/ProviderSatangPro.js
+++ b/src/ProviderSatangPro.js
@@ -1,0 +1,28 @@
+const Lang = imports.lang;
+
+const Local = imports.misc.extensionUtils.getCurrentExtension();
+const BaseProvider = Local.imports.BaseProvider;
+
+
+const Api = new Lang.Class({
+  Name: "SatangPro.Api",
+  Extends: BaseProvider.Api,
+
+  apiName: "Satang.pro",
+
+  apiDocs: [
+    ["API Docs", "https://docs.satang.pro/apis/public/orders"]
+  ],
+
+  interval: 60, // unclear, should be safe
+
+  getUrl({ base, quote }) {
+    return `https://api.tdax.com/api/orders/?pair=${base}_${quote}`;
+  },
+
+  getLast(data) {
+    var bidding = parseFloat(data['bid'][0]['price']);
+    var asking = parseFloat(data['ask'][0]['price']);
+    return ((asking - bidding) * 0.5) + bidding;
+  }
+});


### PR DESCRIPTION
BX.in.th will ceasing trading at the the end of September. The prices their API is producing are no longer reflective of the larger markets.

Satang.pro have a more reliable source of data for THB pricing.