### PR TITLE
Fix for  #98 and #90

### DIFF
--- a/src/BaseProvider.js
+++ b/src/BaseProvider.js
@@ -31,10 +31,6 @@ const Api = new Lang.Class({
         return reject(this.permanentError);
       }
 
-      if (this.pendingRequest) {
-        this.pendingRequest.cancel();
-      }
-
       this.pendingRequest = HTTP.getJSON(url);
 
       return this.pendingRequest


### PR DESCRIPTION
Cancelling a pending request seems to cause bugs, especially when resuming from a locked screen.