### PR TITLE
Buda exchange support added

### DIFF
--- a/src/ApiService.ts
+++ b/src/ApiService.ts
@@ -11,6 +11,7 @@ import * as ProviderBitso from './providers/ProviderBitso';
 import * as ProviderBitstamp from './providers/ProviderBitstamp';
 import * as ProviderBlinktrade from './providers/ProviderBlinktrade';
 import * as ProviderBTCMarkets from './providers/ProviderBTCMarkets';
+import * as ProviderBuda from './providers/ProviderBuda';
 import * as ProviderBXinTH from './providers/ProviderBXinTH';
 import * as ProviderCexio from './providers/ProviderCexio';
 import * as ProviderCoinbase from './providers/ProviderCoinbase';
@@ -37,6 +38,7 @@ export const Providers: Record<string, BaseProvider.Api> = {
   bitstamp: new ProviderBitstamp.Api(),
   blinktrade: new ProviderBlinktrade.Api(),
   btcmarkets: new ProviderBTCMarkets.Api(),
+  buda: new ProviderBuda.Api(),
   bxinth: new ProviderBXinTH.Api(),
   cexio: new ProviderCexio.Api(),
   coinbase: new ProviderCoinbase.Api(),

--- a/src/providers/ProviderBuda.ts
+++ b/src/providers/ProviderBuda.ts
@@ -1,0 +1,17 @@
+import * as BaseProvider from '../BaseProvider';
+
+export class Api extends BaseProvider.Api {
+  apiName = 'Buda';
+
+  apiDocs = [['API Docs', 'https://api.buda.com/#la-api-de-buda-com']];
+
+  interval = 60;
+
+  getUrl({ base, quote }) {
+    return `https://www.buda.com/api/v2/markets/${base}-${quote}/ticker`;
+  }
+
+  getLast({ ticker }) {
+    return ticker.last_price[0];
+  }
+}


### PR DESCRIPTION
Hello!

I would like to add support to *Buda*. *Buda* is an exchange that allow us to sell and buy cryptocurrencies in Latin American context using local currencies (Argentina, Perú, Colombia and Chile).

Thanks.