### PR TITLE
Divided by 0.001 should be Divided by 1000.

### DIFF
--- a/dist/prefs.js
+++ b/dist/prefs.js
@@ -140,7 +140,7 @@ var prefs = (function (Gtk, GObject, Gio, Soup) {
             ['bs', _('Base currency symbol')],
             ['btc', _('Bitcoin symbol (₿)')],
             ['v', _('formatted value with defaults')],
-            ['mv', _('formatted value with defaults, divided by ') + (0.001).toLocaleString()],
+            ['mv', _('formatted value with defaults, divided by ') + (1000).toLocaleString()],
             ['kv', _('formatted value with defaults, multiplied by ') + (1000).toLocaleString()],
             ['satv', _('formatted value with defaults, multiplied by ') + (1e8).toLocaleString()],
             ['(m|k|sat)v0', _('formatted value with 0 decimals')],


### PR DESCRIPTION
The text for "mv" says "Divided by 0.001", this is in fact multiply by 1000, while the actual functionality is divide by 1000. Changed the text accordingly (in the same style as all other multipliers).

(Pedantic math pull request alert!)