### PR TITLE
add Gnome 41

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["40"],
+  "shell-version": ["40", "41"],
   "uuid": "bitcoin-markets@ottoallmendinger.github.com",
   "name": "Bitcoin Markets",
   "url": "https://github.com/OttoAllmendinger/gnome-shell-bitcoin-markets/",


### PR DESCRIPTION
gnome 41 does not seem to have any compatibility issues so far and just works.