### PR TITLE
Support `gnome-shell` v43

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["44"],
+  "shell-version": ["43", "44"],
   "uuid": "bitcoin-markets@ottoallmendinger.github.com",
   "name": "Bitcoin Markets",
   "url": "https://github.com/OttoAllmendinger/gnome-shell-bitcoin-markets/",


### PR DESCRIPTION
@OttoAllmendinger, in the last update you removed the support for `gnome-shell` v43 for no reason. The only change had been made in the plugin's latest version , is adding a new exchange (which I did).

Users that running `gnome-shell` v43 (including me) are not getting the new update for no real reason. 

Please merge this change, and release a new version for additional users. 

Thanks.