### PR TITLE
Add GNOME 47 to version list

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["46"],
+  "shell-version": ["46", "47"],
   "uuid": "bitcoin-markets@ottoallmendinger.github.com",
   "name": "Bitcoin Markets",
   "url": "https://github.com/OttoAllmendinger/gnome-shell-bitcoin-markets/",


### PR DESCRIPTION
AFAICT based on https://gjs.guide/extensions/upgrading/gnome-shell-47.html, there's nothing else to do for compatibility. #158 